### PR TITLE
feat: ETF sector price data to Redshift

### DIFF
--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -18,7 +18,7 @@ def get_last_week_dates(execution_date_str):
     execution_date = datetime.strptime(execution_date_str, "%Y-%m-%d")
 
     start_date = execution_date - timedelta(days=6)
-    end_date = execution_date - timedelta(days=2)
+    end_date = execution_date - timedelta(days=1)
     
     return start_date, end_date
 
@@ -50,7 +50,7 @@ def get_historical_data(execution_date_str, symbols):
         last_week_data = fetch_ETF_data(sec, sym, st, en)
 
         last_week_data["Date"] = pd.to_datetime(last_week_data["Date"])
-        full_date_range = pd.date_range(start=st, end=en+timedelta(days=2), freq="D")
+        full_date_range = pd.date_range(start=st, end=en+timedelta(days=1), freq="D")
         last_week_data = last_week_data.set_index("Date").reindex(full_date_range).reset_index()
         last_week_data.rename(columns={"index": "Date"}, inplace=True)
         last_week_data["sector"] = last_week_data["sector"].fillna(sec)

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -56,7 +56,6 @@ def get_historical_data(symbols):
         last_week_data = last_week_data.set_index("Date").reindex(full_date_range).reset_index()
         last_week_data.rename(columns={"index": "Date"}, inplace=True)
         last_week_data["sector"] = last_week_data["sector"].fillna(sec)
-        
         full_data = pd.concat([full_data, last_week_data])
     
     return full_data
@@ -83,14 +82,23 @@ def load(schema, table, records):
         cur.execute("BEGIN;")
         _create_table(cur, schema, table, False)
 
-        for _, r in records.iterrows():
-            sql = f"""
-                INSERT INTO {schema}.{table} 
-                VALUES ('{r[0]}',
-                        '{r[4]}',
-                        '{r[1]}',
-                        '{r[2]}',
-                        {r[3]});"""
+        for _, values in records.iterrows():
+            if pd.isna(values[1]):
+                sql = f"""
+                    INSERT INTO {schema}.{table}
+                    VALUES ({values[0],
+                            values[4],
+                            null,
+                            null,
+                            null});"""
+            else:
+                sql = f"""
+                    INSERT INTO {schema}.{table} 
+                    VALUES ({values[0]},
+                            {values[4]},
+                            {values[1]},
+                            {values[2]},
+                            {values[3]});"""
             print(sql)
             cur.execute(sql)
 

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -61,9 +61,7 @@ def get_historical_data(symbols):
     return full_data
 
 
-def _create_table(cur, schema, table, drop_first):
-    if drop_first:
-        cur.execute(f"DROP TABLE IF EXISTS {schema}.{table};")
+def _create_table(cur, schema, table):
     cur.execute(f"""
         CREATE TABLE IF NOT EXISTS {schema}.{table} (
             date date,
@@ -80,7 +78,7 @@ def load(schema, table, records):
     cur = get_Redshift_connection()
     try:
         cur.execute("BEGIN;")
-        _create_table(cur, schema, table, False)
+        _create_table(cur, schema, table)
 
         for _, values in records.iterrows():
             if pd.isna(values[1]):

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -14,11 +14,11 @@ def get_Redshift_connection(autocommit=True):
     return conn.cursor()
 
 
-def get_last_week_dates(execution_date_str):
+def get_next_week_dates(execution_date_str):
     execution_date = datetime.strptime(execution_date_str, "%Y-%m-%d")
 
-    start_date = execution_date - timedelta(days=6)
-    end_date = execution_date - timedelta(days=1)
+    start_date = execution_date + timedelta(days=1)
+    end_date = execution_date + timedelta(days=6)
     
     return start_date, end_date
 
@@ -46,7 +46,7 @@ def get_historical_data(execution_date_str, symbols):
     full_data = pd.DataFrame()
     
     for sec, sym in symbols.items():
-        st, en = get_last_week_dates(execution_date_str)
+        st, en = get_next_week_dates(execution_date_str)
         last_week_data = fetch_ETF_data(sec, sym, st, en)
 
         last_week_data["Date"] = pd.to_datetime(last_week_data["Date"])
@@ -136,4 +136,4 @@ with DAG(
 }
     execution_date_str = '{{ ds }}'
     results = get_historical_data(execution_date_str, symbols)
-    load(여기에 schema 입력, "ETF", results)
+    load("musk82155", "ETF", results)

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -1,0 +1,134 @@
+from airflow import DAG
+from airflow.decorators import task
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from datetime import datetime, timedelta
+
+import yfinance as yf
+import pandas as pd
+import numpy as np
+import logging
+
+def get_Redshift_connection(autocommit=True):
+    hook = PostgresHook(postgres_conn_id='redshift_dev_db')
+    conn = hook.get_conn()
+    conn.autocommit = autocommit
+    return conn.cursor()
+
+
+def get_last_week_dates():
+    today = datetime.today() 
+    weekday = today.weekday()
+
+    last_friday = today - timedelta(days=weekday+3)
+    last_monday = last_friday - timedelta(days=4)
+    
+    return last_monday, last_friday
+
+
+def fetch_ETF_data(sector, symbol, start_date, end_date):
+    data = pd.DataFrame()   # Date, open, close, volume, sector
+    
+    ticker = yf.Ticker(symbol)
+    history = ticker.history(start=start_date, end=end_date)
+
+    data['open'] = round(history['Open'], 3)
+    data['close'] = round(history['Close'], 3)
+    data['volume'] = history['Volume']
+    data['sector'] = sector
+
+    data.reset_index(inplace=True)
+    data.rename(columns={'index': 'Date'}, inplace=True)
+    data['Date'] = data['Date'].dt.date
+    
+    return data
+
+
+@task
+def get_historical_data(symbols):
+    full_data = pd.DataFrame()
+    
+    for sec, sym in symbols.items():
+        lm, lf = get_last_week_dates()
+        last_week_data = fetch_ETF_data(sec, sym, lm, lf)
+        
+        last_week_data["Date"] = pd.to_datetime(last_week_data["Date"])
+        full_date_range = pd.date_range(start=last_week_data["Date"].min(), end=datetime.today().date(), freq="D")
+        last_week_data = last_week_data.set_index("Date").reindex(full_date_range).reset_index()
+        last_week_data.rename(columns={"index": "Date"}, inplace=True)
+        last_week_data["sector"] = last_week_data["sector"].fillna(sec)
+        
+        full_data = pd.concat([full_data, last_week_data])
+    
+    return full_data
+
+
+def _create_table(cur, schema, table, drop_first):
+    if drop_first:
+        cur.execute(f"DROP TABLE IF EXISTS {schema}.{table};")
+    cur.execute(f"""
+        CREATE TABLE IF NOT EXISTS {schema}.{table} (
+            date date,
+            sector varchar(20) NOT NULL,
+            open_value float,
+            close_value float,
+            volume bigint
+        );""")
+
+
+@task
+def load(schema, table, records):
+    logging.info("load started")
+    cur = get_Redshift_connection()
+    try:
+        cur.execute("BEGIN;")
+        _create_table(cur, schema, table, False)
+
+        for r in records:
+            sql = f"""
+                INSERT INTO {schema}.{table} 
+                VALUES ('{r[0]}',
+                        '{r[4]}',
+                        '{r[1]}',
+                        '{r[2]}',
+                        {r[3]});"""
+            print(sql)
+            cur.execute(sql)
+
+        cur.execute("COMMIT;")
+
+    except Exception as error:
+        print(error)
+        cur.execute("ROLLBACK;")
+        raise
+
+    logging.info("load complete")
+
+
+with DAG(
+    dag_id = 'ETF_dag',
+    start_date = datetime(2023, 1, 1),
+    catchup=True,
+    tags=['ETF'],
+    schedule = '0 15 * * 0',
+    max_active_runs=1,
+) as dag:
+    symbols = {
+    "산업" : "XLI",
+    "헬스케어" : "XLV",
+    "소비재" : "XLY",
+    "소비재 필수품" : "XLP",
+    "기술" : "XLK",
+    "금융" : "XLF",
+    "에너지" : "XLE",
+    "통신" : "XLC",
+    "유틸리티" : "XLU",
+    "부동산" : "XLRE",
+    "재료" : "XLB",
+    "생명공학" : "XBI",
+    "반도체" : "SMH",
+    "금속/광업" : "XME",
+    "농업" : "MOO",
+    "수송" : "IYT" 
+}
+    results = get_historical_data(symbols)
+    load("musk82155", "ETF", results)

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -17,8 +17,8 @@ def get_Redshift_connection(autocommit=True):
 def get_last_week_dates(execution_date_str):
     execution_date = datetime.strptime(execution_date_str, "%Y-%m-%d")
 
-    start_date = execution_date - timedelta(days=6)
-    end_date = execution_date - timedelta(days=1)
+    start_date = execution_date + timedelta(days=1)
+    end_date = execution_date + timedelta(days=6)
     
     return start_date, end_date
 
@@ -136,4 +136,4 @@ with DAG(
 }
     execution_date_str = '{{ ds }}'
     results = get_historical_data(execution_date_str, symbols)
-    load(여기에 schema 입력, "ETF", results)
+    load("musk82155", "ETF", results)

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -83,7 +83,7 @@ def load(schema, table, records):
         cur.execute("BEGIN;")
         _create_table(cur, schema, table, False)
 
-        for r in records:
+        for _, r in records.iterrows():
             sql = f"""
                 INSERT INTO {schema}.{table} 
                 VALUES ('{r[0]}',

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -136,4 +136,4 @@ with DAG(
 }
     execution_date_str = '{{ ds }}'
     results = get_historical_data(execution_date_str, symbols)
-    load("musk82155", "ETF", results)
+    load(여기에 schema 입력, "ETF", results)

--- a/dags/ETF_dag.py
+++ b/dags/ETF_dag.py
@@ -86,16 +86,16 @@ def load(schema, table, records):
             if pd.isna(values[1]):
                 sql = f"""
                     INSERT INTO {schema}.{table}
-                    VALUES ({values[0],
-                            values[4],
+                    VALUES ('{datetime.date(values[0])}',
+                            '{values[4]}',
                             null,
                             null,
-                            null});"""
+                            null);"""
             else:
                 sql = f"""
                     INSERT INTO {schema}.{table} 
-                    VALUES ({values[0]},
-                            {values[4]},
+                    VALUES ('{datetime.date(values[0])}',
+                            '{values[4]}',
                             {values[1]},
                             {values[2]},
                             {values[3]});"""


### PR DESCRIPTION
**📜 개요**
- sector별 ETF에 대한 데이터를 ETL하여 Redshift 에 적재하는 기능을 태스크와 메소드별로 나열합니다.
- feature/ 브랜치에서 main으로 merge 됩니다.

**⁉️ 변경사항**
- DAG는 catchup이 True로 설정되어 있습니다.
- DAG는 매주 일요일 15시에 실행되고 2023년 1월 1일부터 시작합니다.
- DAG 태스크 1
  a. 실행 날짜를 기준으로 데이터를 가져와야 하는 날짜 계산
  b. 계산한 날짜의 데이터와 비어있는 날짜의 데이터를 만들어 적재할 최종 데이터 준비
- DAG 태스크 2
  a. 레드시프트에 연결 후,
  b. 테이블이 없다면 생성하고,
  c. 레드시프트에 업로드 합니다

**✔️ 체크**
- [x] 코드 작동 확인
- [x] 브랜치 설정 확인
- [x] 변경사항이 브랜치에 반영되어있는지
- [ ] Merge 후 작동 상태

**🕵️‍♀️ 리뷰**
- 로직과 성능의 개선 여지가 있는지 검토 부탁드립니다.

**📝 참고**
- 없음