### PR TITLE
feat: Implement foreign exchange rate data pipeline

### DIFF
--- a/dags/forexrate_dag.py
+++ b/dags/forexrate_dag.py
@@ -1,0 +1,118 @@
+from airflow import DAG
+from airflow.decorators import task
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from datetime import datetime
+
+import pandas as pd
+import yfinance as yf
+import logging
+
+
+def get_Redshift_connection(autocommit=True):
+    hook = PostgresHook(postgres_conn_id='redshift_dev_db')
+    conn = hook.get_conn()
+    conn.autocommit = autocommit
+    return conn.cursor()
+
+
+@task
+def get_historical_prices(symbols, start_date, end_date):
+    records = []
+    all_dates = pd.date_range(start=start_date, end=end_date, freq='D').strftime("%Y-%m-%d").tolist()
+
+    for name, symbol in symbols.items():
+        ticket = yf.Ticker(symbol)
+        data = ticket.history(start=start_date, end=end_date)
+        
+        fetched_dates = set()
+        for index, row in data.iterrows():
+            date_str = index.strftime("%Y-%m-%d")
+            fetched_dates.add(date_str)
+            records.append([
+                date_str,
+                name, 
+                row["Open"], 
+                row["Close"],
+                row["Volume"]
+            ])
+
+        missing_dates = set(all_dates) - fetched_dates
+        for missing_date in missing_dates:
+            records.append([missing_date, name, None, None, None])
+
+    return records
+
+
+@task
+def load(schema, table, records):
+    logging.info("load started")
+    cur = get_Redshift_connection()
+    try:
+        # full refresh
+        cur.execute("BEGIN;")
+        cur.execute(f"DROP TABLE IF EXISTS {schema}.{table};")
+        cur.execute(f"""
+        CREATE TABLE {schema}.{table} (
+            date date,
+            name varchar(20),
+            open_value float,
+            close_value float,
+            volume bigint
+        );""")
+        
+        # 
+        for r in records:
+            sql = f"INSERT INTO {schema}.{table} VALUES (%s, %s, %s, %s, %s);"
+            print(sql)
+            cur.execute(sql, r)
+
+        cur.execute("COMMIT;")
+
+    except Exception as error:
+        print(error)
+        cur.execute("ROLLBACK;")
+        raise
+
+    logging.info("load done")
+
+
+with DAG(
+    dag_id = 'forex_rate',
+    start_date = datetime(2023,1,8),
+    catchup=False,
+    tags=['API'],
+    schedule = '0 15 * * 0'
+) as dag:
+    # 자산 심볼 정의
+    symbols = {
+    "EUR/USD": "EURUSD=X",       
+    "USD/JPY": "JPY=X", 
+    "GBP/USD": "GBPUSD=X",     
+    "AUD/USD": "AUDUSD=X",   
+    "NZD/USD": "NZDUSD=X",     
+    "EUR/JPY": "EURJPY=X",  
+    "GBP/JPY": "GBPJPY=X",  
+    "EUR/GBP": "EURGBP=X", 
+    "EUR/CAD": "EURCAD=X",
+    "EUR/SEK": "EURSEK=X",
+    "EUR/CHF": "EURCHF=X",
+    "EUR/HUF": "EURHUF=X",
+    "USD/CNY": "CNY=X",
+    "USD/HKD": "HKD=X",
+    "USD/SGD": "SGD=X",
+    "USD/INR": "INR=X",
+    "USD/MXN": "MXN=X", 
+    "USD/PHP": "PHP=X", 
+    "USD/IDR": "IDR=X", 
+    "USD/THB": "THB=X", 
+    "USD/MYR": "MYR=X", 
+    "USD/ZAR": "ZAR=X", 
+    "USD/RUB": "RUB=X", 
+    }
+
+    start_date = "2023-01-01"
+    end_date = "{{ ds }}"
+
+    results = get_historical_prices(symbols, start_date, end_date)
+    load("eumjungmin1", "forex_rate", results)
+    

--- a/dags/forexrate_dag.py
+++ b/dags/forexrate_dag.py
@@ -21,7 +21,7 @@ def get_date_range(start_date, end_date):
     end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
     
     # 날짜 범위 생성 (end_date는 포함되지 않도록 설정)
-    date_list = pd.date_range(start=start_date_obj, end=end_date_obj - timedelta(days=1)).strftime("%Y-%m-%d").tolist()
+    date_list = pd.date_range(start=start_date_obj, end=end_date_obj).strftime("%Y-%m-%d").tolist()
     
     return date_list
 
@@ -31,11 +31,6 @@ def get_historical_prices(symbols, **context):
     start_date = context['ds']
     end_date = (datetime.strptime(start_date, "%Y-%m-%d") + timedelta(days=7)).strftime("%Y-%m-%d")
     all_dates = get_date_range(start_date, end_date)
-    print("======================================")
-    print("start_date: ", start_date)
-    print("end_date = execution_date = ds: ", end_date)
-    print("all_dates: ", all_dates)
-    print("======================================")
 
     records = []
     for name, symbol in symbols.items():


### PR DESCRIPTION
**📜 개요**
- KRW를 제외한 국제 환율 정보를 ETL하여 Redshift 에 적재하는 기능을 태스크와 메소드별로 나열합니다.
- feature/forexrate 에서 main으로 merge 됩니다.

**⁉️ 변경사항**
- 대그는 catchup, incremental update 룰을 따릅니다
- 대그는 매주 일요일 15시에 실행되고 2023년 1월 1일부터 시작합니다.
- 대그 태스크 1
  a. yahoo finance를 활용해서 심볼을 이용한 국제 환율 데이터를 요청합니다.
  b. 날짜, 이름, 시작가, 종가, 거래량을 수집합니다
- 대그 태스크 2
  a. 레드시프트에 연결 후,
  b. 테이블이 없다면 생성하고,
  c. 레드시프트에 업로드 합니다

**✔️ 체크**
- [x] 코드 작동 확인
- [x] 브랜치 설정 확인
- [x] 변경사항이 브랜치에 반영되어있는지
- [x] Merge 후 작동 상태

**🕵🏽‍♀️ 리뷰**
- 로직과 성능의 개선 여지가 있는지 검토 부탁드립니다.

**📝 참고**
- 없음