### PR TITLE
fix: add comment

### DIFF
--- a/dags/rawmaterials_dag.py
+++ b/dags/rawmaterials_dag.py
@@ -29,13 +29,13 @@ def create_table(cur, schema, table, drop_first):
         );
         """)
 
-# 날짜 범위 태스크
+
+# 날짜 범위 계산 태스크
 @task
 def get_date_range(execution_date_str):
-    # execution_date 기준으로 지난 일주일 범위 계산
     execution_date = datetime.strptime(execution_date_str, "%Y-%m-%d")
     start_date = (execution_date - timedelta(days=6)).strftime("%Y-%m-%d")
-    end_date = execution_date.strftime("%Y-%m-%d")
+    end_date = (execution_date + timedelta(days=1)).strftime("%Y-%m-%d")  # 다음 날까지 포함
     return {"start_date": start_date, "end_date": end_date}
 
 

--- a/dags/rawmaterials_dag.py
+++ b/dags/rawmaterials_dag.py
@@ -7,14 +7,14 @@ import pandas as pd
 import yfinance as yf
 import logging
 
-
+# DB Connect
 def get_Redshift_connection(autocommit=True):
     hook = PostgresHook(postgres_conn_id='redshift_dev_db')
     conn = hook.get_conn()
     conn.autocommit = autocommit
     return conn.cursor()
 
-
+# Date range
 def get_date_range(start_date, end_date):
     # start_date와 end_date는 문자열이므로 datetime으로 변환
     start_date_obj = datetime.strptime(start_date, "%Y-%m-%d")
@@ -25,7 +25,7 @@ def get_date_range(start_date, end_date):
     
     return date_list
 
-
+# Task 1 Extract data
 @task
 def get_historical_prices(symbols, **context):
     start_date = context['ds']
@@ -55,7 +55,7 @@ def get_historical_prices(symbols, **context):
 
     return records
 
-
+# Create Table
 def _create_table(cur, schema, table, drop_first):
     if drop_first:
         cur.execute(f"DROP TABLE IF EXISTS {schema}.{table};")
@@ -68,7 +68,7 @@ def _create_table(cur, schema, table, drop_first):
             volume bigint
         );""")
 
-
+# Task 2 Load data
 @task
 def load(schema, table, records):
     logging.info("load started")

--- a/dags/rawmaterials_dag.py
+++ b/dags/rawmaterials_dag.py
@@ -29,7 +29,7 @@ def create_table(cur, schema, table, drop_first):
         );
         """)
 
-# 날짜 범위
+# 날짜 범위 태스크
 @task
 def get_date_range(execution_date_str):
     # execution_date 기준으로 지난 일주일 범위 계산


### PR DESCRIPTION
📜 개요
- yfinance 라이브러리의 원자재 데이터를 ETL하여 Redshift 에 적재하는 기능을 태스크와 메소드별로 나열합니다.
- feature/ 브랜치에서 main으로 merge 됩니다.

⁉️ 변경사항
- DAG는 catchup=True, 단순 insert(Incremental Insert) 룰을 따릅니다.
- DAG는 매주 일요일 15시에 실행되고 2023년 1월 1일부터 시작합니다.
- DAG task 1
a. yfinance 라이브러리로부터 데이터를 추출
b. 휴장일을 구분하여 데이터 준비
- DAG task 2
a. 레드시프트에 연결
b. 테이블이 없다면 생성
c. 레드시프트에 업로드

✔️ 체크
- [x] 코드 작동 확인
- [x] 브랜치 설정 확인
- [x] 변경사항이 브랜치에 반영되어있는지
- [ ] Merge 후 작동 상태

🕵️‍♀️ 리뷰
- 로직과 성능의 개선 여지가 있는지 검토 부탁드립니다.

📝 참고
- 없음.